### PR TITLE
Fix cpants prereq warnings

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -27,7 +27,7 @@ requires 'MooseX::MultiInitArg';
 requires 'MooseX::StrictConstructor';
 requires 'MooseX::TrackDirty::Attributes';
 requires 'MooseX::Types';
-requires 'MooseX::Types::DateTime';
+requires 'MooseX::Types::DateTimeX';
 requires 'MooseX::Types::Path::Class';
 requires 'MooseX::Types::URI';
 requires 'Regexp::Common';

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -30,6 +30,7 @@ requires 'MooseX::Types';
 requires 'MooseX::Types::DateTimeX';
 requires 'MooseX::Types::Path::Class';
 requires 'MooseX::Types::URI';
+requires 'Path::Class'
 requires 'Regexp::Common';
 requires 'URI::Fetch';
 requires 'URI::Find';

--- a/lib/Fedora/Bugzilla/NewBug.pm
+++ b/lib/Fedora/Bugzilla/NewBug.pm
@@ -23,7 +23,6 @@ use MooseX::AttributeHelpers;
 
 use Moose::Util::TypeConstraints;
 use MooseX::Types::URI qw{ Uri };
-use MooseX::Types::DateTime qw{ DateTime };
 
 
 use MooseX::MarkAsMethods autoclean => 1;


### PR DESCRIPTION
These diffs should fix the CPANTS warnings listed here:

http://cpants.cpanauthors.org/dist/Fedora-Bugzilla/errors
